### PR TITLE
build(deps): update N3 parser (uses latest readable-stream)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/rdfjs-base/formats-common",
   "dependencies": {
-    "@rdfjs/parser-jsonld": "^1.1.1",
-    "@rdfjs/parser-n3": "^1.1.2",
-    "@rdfjs/serializer-jsonld": "^1.2.0",
-    "@rdfjs/serializer-ntriples": "^1.0.1",
+    "@rdfjs/parser-jsonld": "^1.2.1",
+    "@rdfjs/parser-n3": "^1.1.4",
+    "@rdfjs/serializer-jsonld": "^1.2.2",
+    "@rdfjs/serializer-ntriples": "^1.0.3",
     "@rdfjs/sink-map": "^1.0.0",
     "rdfxml-streaming-parser": "^1.2.0"
   },


### PR DESCRIPTION
Fixes #4 

Will be ready to review when all upstream packages are updated to use readable-stream 3.x