### PR TITLE
chore: add export to lessen breaking change

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ import SinkMap from '@rdfjs/sink-map'
 import JsonLdSerializer from './lib/CustomJsonLdSerializer.js'
 import RdfXmlParser from './lib/CustomRdfXmlParser.js'
 
-export const parsers = new SinkMap()
-export const serializers = new SinkMap()
+const parsers = new SinkMap()
+const serializers = new SinkMap()
 
 const formats = {
   parsers,
@@ -27,6 +27,7 @@ formats.serializers.set('application/n-triples', new NTriplesSerializer())
 formats.serializers.set('text/n3', new NTriplesSerializer())
 formats.serializers.set('text/turtle', new NTriplesSerializer())
 
+export { parsers, serializers }
 export default formats
 export {
   JsonLdParser,

--- a/index.js
+++ b/index.js
@@ -5,9 +5,12 @@ import SinkMap from '@rdfjs/sink-map'
 import JsonLdSerializer from './lib/CustomJsonLdSerializer.js'
 import RdfXmlParser from './lib/CustomRdfXmlParser.js'
 
+export const parsers = new SinkMap()
+export const serializers = new SinkMap()
+
 const formats = {
-  parsers: new SinkMap(),
-  serializers: new SinkMap()
+  parsers,
+  serializers
 }
 
 formats.parsers.set('application/ld+json', new JsonLdParser())


### PR DESCRIPTION
Up to version 2, the package could have been imported in two ways, both from commonjs and modules

```js
const formats = require('@rdfjs/formats-common')
const { parsers } = require('@rdfjs/formats-common')
```

```js
import formats from '@rdfjs/formats-common'
import { parsers } from '@rdfjs/formats-common'
```

With v3, the named import will no longer work and this will force any such usage to be updated. 

By adding named exports for `parsers` and `serializers`, existing usages as named imports will not break existing projects